### PR TITLE
adding a public accessor to JsonPatch to retrieve the contained opera…

### DIFF
--- a/src/main/java/com/github/fge/jsonpatch/JsonPatch.java
+++ b/src/main/java/com/github/fge/jsonpatch/JsonPatch.java
@@ -177,4 +177,8 @@ public class JsonPatch
     {
         serialize(jgen, provider);
     }
+
+    public List<JsonPatchOperation> getOperations() {
+        return ImmutableList.copyOf(operations);
+    }
 }

--- a/src/test/java/com/github/fge/jsonpatch/JsonPatchTest.java
+++ b/src/test/java/com/github/fge/jsonpatch/JsonPatchTest.java
@@ -31,6 +31,7 @@ import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
 import java.io.IOException;
+import java.util.List;
 
 import static org.mockito.Mockito.*;
 import static org.testng.Assert.*;
@@ -119,5 +120,16 @@ public final class JsonPatchTest
         }
 
         verifyZeroInteractions(op2);
+    }
+
+    @Test
+    public void getOperationsReturnsTheCorrectOpsInTheCorrectOrder()
+    {
+        final JsonPatch patch = new JsonPatch(ImmutableList.of(op1, op2));
+
+        List<JsonPatchOperation> operations = patch.getOperations();
+        assertEquals(operations.size(), 2);
+        assertEquals(operations.get(0), op1);
+        assertEquals(operations.get(1), op2);
     }
 }


### PR DESCRIPTION
I have a case where I have a library that receives a JsonPatch doc. Before applying the patch to another Json doc, my library needs to validate the contents of the JsonPatch. For example you may not replace certain values at certain paths or you must have a particular role to be able to perform particular patch operations. So I need to iterate and validate each operation within the JsonPatch object in order to perform custom validation. In order to do this, I need JsonPatch class to be able to expose the underlying List<JsonPatchOperation>. This pull request has a change to include a public getOperations() method on the JsonPatch class to return an Immutable copy of the internal operations list.
